### PR TITLE
fix(lancamentos): remover chaves duplicadas e acelerar Select; feat: banner “Homologação” e botão “Limpar” filtros

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -7,6 +7,7 @@ interface LayoutProps {
 }
 
 export function Layout({ children }: LayoutProps) {
+  const env = import.meta.env.VITE_ENVIRONMENT as string | undefined;
   return (
     <SidebarProvider>
       <div className="min-h-screen flex w-full bg-white">
@@ -16,6 +17,11 @@ export function Layout({ children }: LayoutProps) {
           <header className="bg-white px-6 py-4 flex items-center justify-between">
             <div className="flex items-center space-x-4">
               <SidebarTrigger className="lg:hidden" />
+              {env === "homolog" && (
+                <span className="text-xs px-2 py-1 rounded border bg-amber-50 text-amber-800 border-amber-200">
+                  Homologação
+                </span>
+              )}
             </div>
           </header>
           

--- a/src/hooks/useAccountHierarchy.tsx
+++ b/src/hooks/useAccountHierarchy.tsx
@@ -51,33 +51,46 @@ export function useAccountHierarchy(filters?: {
 
 export function useLevel1Options() {
   const { data: hierarchy = [] } = useAccountHierarchy();
-  
-  const level1Options = [...new Set(hierarchy.map(item => item.level_1).filter(Boolean))];
+  const norm = (s?: string | null) => (s ?? "").normalize("NFC").replace(/\s+/g, " ").trim();
+  const level1Options = Array.from(
+    new Set(
+      hierarchy
+        .map((item) => norm(item.level_1))
+        .filter((v) => v.length > 0)
+    )
+  );
   return level1Options;
 }
 
 export function useLevel2Options(level1?: string) {
   const { data: hierarchy = [] } = useAccountHierarchy();
-  
-  const level2Options = hierarchy
-    .filter(item => !level1 || item.level_1 === level1)
-    .map(item => item.level_2)
-    .filter(Boolean)
-    .filter((value, index, array) => array.indexOf(value) === index);
-    
+  const norm = (s?: string | null) => (s ?? "").normalize("NFC").replace(/\s+/g, " ").trim();
+  const l1 = norm(level1);
+  const level2Options = Array.from(
+    new Set(
+      hierarchy
+        .filter((item) => !l1 || norm(item.level_1) === l1)
+        .map((item) => norm(item.level_2))
+        .filter((v) => v.length > 0)
+    )
+  );
   return level2Options;
 }
 
 export function useAnalyticalAccountOptions(level1?: string, level2?: string) {
   const { data: hierarchy = [] } = useAccountHierarchy();
-  
-  const analyticalOptions = hierarchy
-    .filter(item => 
-      (!level1 || item.level_1 === level1) && 
-      (!level2 || item.level_2 === level2)
+  const norm = (s?: string | null) => (s ?? "").normalize("NFC").replace(/\s+/g, " ").trim();
+  const l1 = norm(level1);
+  const l2 = norm(level2);
+  const analyticalOptions = Array.from(
+    new Set(
+      hierarchy
+        .filter(
+          (item) => (!l1 || norm(item.level_1) === l1) && (!l2 || norm(item.level_2) === l2)
+        )
+        .map((item) => norm(item.analytical_account))
+        .filter((v) => v.length > 0)
     )
-    .map(item => item.analytical_account)
-    .filter(Boolean);
-    
+  );
   return analyticalOptions;
 }

--- a/src/pages/Lancamentos.tsx
+++ b/src/pages/Lancamentos.tsx
@@ -633,9 +633,15 @@ export default function Lancamentos() {
                     <SelectValue placeholder="Selecione o grupo" />
                   </SelectTrigger>
                   <SelectContent className="bg-white border-gray-300 z-50">
-                     {level1Options.map(grupo => <SelectItem key={grupo || ""} value={grupo || ""} className="bg-white hover:bg-blue-100 focus:bg-blue-100 focus:text-blue-900">
+                     {level1Options.map((grupo, i) => (
+                       <SelectItem
+                         key={`l1-${i}`}
+                         value={grupo || ""}
+                         className="bg-white hover:bg-blue-100 focus:bg-blue-100 focus:text-blue-900"
+                       >
                          {grupo}
-                       </SelectItem>)}
+                       </SelectItem>
+                     ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -647,9 +653,17 @@ export default function Lancamentos() {
                     <SelectValue placeholder={formData.grupoContas1 ? "Selecione o grupo" : "Primeiro selecione o 1º nível"} />
                   </SelectTrigger>
                   <SelectContent className="bg-white border-gray-300 z-50">
-                     {level2Options.length > 0 ? level2Options.map(grupo => <SelectItem key={grupo || ""} value={grupo || ""} className="bg-white hover:bg-blue-100 focus:bg-blue-100 focus:text-blue-900">
-                           {grupo}
-                         </SelectItem>) : null}
+                     {level2Options.length > 0
+                       ? level2Options.map((grupo, i) => (
+                           <SelectItem
+                             key={`l2-${i}`}
+                             value={grupo || ""}
+                             className="bg-white hover:bg-blue-100 focus:bg-blue-100 focus:text-blue-900"
+                           >
+                             {grupo}
+                           </SelectItem>
+                         ))
+                       : null}
                   </SelectContent>
                 </Select>
               </div>
@@ -667,9 +681,17 @@ export default function Lancamentos() {
                     <SelectValue placeholder={formData.grupoContas2 ? "Selecione a conta analítica" : "Primeiro selecione o 2º nível"} />
                   </SelectTrigger>
                   <SelectContent className="bg-white border-gray-300 z-50">
-                     {analyticalOptions.length > 0 ? analyticalOptions.map(conta => <SelectItem key={conta || ""} value={conta || ""} className="bg-white hover:bg-blue-100 focus:bg-blue-100 focus:text-blue-900">
-                           {conta}
-                         </SelectItem>) : null}
+                     {analyticalOptions.length > 0
+                       ? analyticalOptions.map((conta, i) => (
+                           <SelectItem
+                             key={`a-${i}`}
+                             value={conta || ""}
+                             className="bg-white hover:bg-blue-100 focus:bg-blue-100 focus:text-blue-900"
+                           >
+                             {conta}
+                           </SelectItem>
+                         ))
+                       : null}
                   </SelectContent>
                 </Select>
               </div>

--- a/src/pages/Lancamentos.tsx
+++ b/src/pages/Lancamentos.tsx
@@ -151,6 +151,11 @@ export default function Lancamentos() {
     // Data is already filtered by the useTransactions hook
     // This function is kept for button compatibility but doesn't do anything
   };
+  const handleClearFilters = () => {
+    setSearchTerm("");
+    setSelectedEmpresa("all");
+    setSelectedPeriodo("");
+  };
   const handleEdit = (transaction: any) => {
     setEditingLancamento(transaction);
     setShowForm(true);
@@ -482,6 +487,14 @@ export default function Lancamentos() {
             <Button variant="outline" className="bg-white border-gray-300 text-gray-700 hover:bg-gray-100 hover:text-gray-900" onClick={handleFilter} disabled={isLoadingTransactions}>
               {isLoadingTransactions ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Filter className="h-4 w-4 mr-2" />}
               Filtrar
+            </Button>
+            <Button 
+              variant="outline" 
+              className="bg-white border-gray-300 text-gray-700 hover:bg-gray-100 hover:text-gray-900"
+              onClick={handleClearFilters}
+              disabled={isLoadingTransactions}
+            >
+              Limpar
             </Button>
           </div>
         </CardContent>


### PR DESCRIPTION
Correções: deduplica e normaliza opções dos selects para evitar “two children with the same key”; usa keys estáveis nos itens.
Melhorias: selo “Homologação” no header quando VITE_ENVIRONMENT=homolog; botão “Limpar” nos filtros de Lançamentos.
Arquivos:
src/components/Layout.tsx:20,22 — banner de ambiente
src/hooks/useAccountHierarchy.tsx:52,65,80 — normalização/deduplicação nas opções
src/pages/Lancamentos.tsx:154,494,636,657,685 — botão “Limpar” e keys estáveis
Teste: abrir “Lançamentos” → “Novo Lançamento”; modal rápido e sem warnings; dropdowns sem duplicados; “Limpar” zera filtros.